### PR TITLE
Update list of invalid owners

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -7,7 +7,26 @@ var inValidOwners = [
   'trending',
   'stars',
   'contact',
-  'about'
+  'about',
+  'orgs',
+  'codespaces',
+  'settings',
+  'marketplace',
+  'pulls',
+  'issues',
+  'notifications',
+  'account',
+  'discussions',
+  'sponsors',
+  'login',
+  'codesearch',
+  'enterprise',
+  'enterprises',
+  'security',
+  'team',
+  'customer-stories',
+  'readme',
+  'pricing'
 ]
 
 // Build a hashmap of accessed repos


### PR DESCRIPTION
Thank you for this extension! I [adapted it](https://github.com/microsoft/vscode-dev-chrome-launcher) to allow opening GitHub repositories in vscode.dev, and as part of that found a few extra invalid owners (`/codespaces` and `/auth` being the most common ones).